### PR TITLE
Rely on autoindent and the streamindentor to indent stack traces

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2431,7 +2431,7 @@ void java_lang_Throwable::print_stack_element(outputStream *st, Method* method, 
   int method_id = method->orig_method_idnum();
   int version = method->constants()->version();
   {
-    StreamAutoIndentor auto_indentor(st, 8);
+    StreamAutoIndentor auto_indentor(st);
     print_stack_element_to_stream(st, mirror, method_id, version, bci, method->name());
   }
 }
@@ -2449,7 +2449,7 @@ void java_lang_Throwable::print_stack_trace(Handle throwable, outputStream* st) 
   JavaThread* THREAD = JavaThread::current(); // For exception macros.
   while (throwable.not_null()) {
     {
-      StreamAutoIndentor auto_indentor(st, 8);
+      StreamAutoIndentor auto_indentor(st);
       objArrayHandle result (THREAD, objArrayOop(backtrace(throwable())));
       if (result.is_null()) {
         st->print_raw_cr("<<no stack trace available>>");

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -2431,7 +2431,7 @@ void java_lang_Throwable::print_stack_element(outputStream *st, Method* method, 
   int method_id = method->orig_method_idnum();
   int version = method->constants()->version();
   {
-    StreamAutoIndentor auto_indentor(st, 8, true);
+    StreamAutoIndentor auto_indentor(st, 8);
     print_stack_element_to_stream(st, mirror, method_id, version, bci, method->name());
   }
 }
@@ -2449,7 +2449,7 @@ void java_lang_Throwable::print_stack_trace(Handle throwable, outputStream* st) 
   JavaThread* THREAD = JavaThread::current(); // For exception macros.
   while (throwable.not_null()) {
     {
-      StreamAutoIndentor auto_indentor(st, 8, true);
+      StreamAutoIndentor auto_indentor(st, 8);
       objArrayHandle result (THREAD, objArrayOop(backtrace(throwable())));
       if (result.is_null()) {
         st->print_raw_cr("<<no stack trace available>>");

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -56,6 +56,7 @@
 #include "nmt/memTracker.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/klass.inline.hpp"
+#include "oops/method.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/symbol.hpp"
 #include "prims/jvm_misc.hpp"

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -56,7 +56,6 @@
 #include "nmt/memTracker.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/klass.inline.hpp"
-#include "oops/method.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/symbol.hpp"
 #include "prims/jvm_misc.hpp"
@@ -1335,7 +1334,7 @@ void Threads::print_on(outputStream* st, bool print_stacks,
             assert(vt != nullptr, "vthread should not be null when vthread is mounted");
             // JavaThread._vthread can refer to the carrier thread. Print only if _vthread refers to a virtual thread.
             if (vt != thread_oop) {
-              streamIndentor si(st, 8, true);
+              StreamAutoIndentor auto_indentor(st, 8);
               st->print_cr("   Mounted virtual thread #" INT64_FORMAT, (int64_t)java_lang_Thread::thread_id(vt));
               p->print_vthread_stack_on(st);
             }

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1334,7 +1334,7 @@ void Threads::print_on(outputStream* st, bool print_stacks,
             assert(vt != nullptr, "vthread should not be null when vthread is mounted");
             // JavaThread._vthread can refer to the carrier thread. Print only if _vthread refers to a virtual thread.
             if (vt != thread_oop) {
-              StreamAutoIndentor auto_indentor(st, 8);
+              StreamAutoIndentor auto_indentor(st);
               st->print_cr("   Mounted virtual thread #" INT64_FORMAT, (int64_t)java_lang_Thread::thread_id(vt));
               p->print_vthread_stack_on(st);
             }

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1335,6 +1335,7 @@ void Threads::print_on(outputStream* st, bool print_stacks,
             assert(vt != nullptr, "vthread should not be null when vthread is mounted");
             // JavaThread._vthread can refer to the carrier thread. Print only if _vthread refers to a virtual thread.
             if (vt != thread_oop) {
+              streamIndentor si(st, 8, true);
               st->print_cr("   Mounted virtual thread #" INT64_FORMAT, (int64_t)java_lang_Thread::thread_id(vt));
               p->print_vthread_stack_on(st);
             }


### PR DESCRIPTION
Example of how I would adapt the code that prints stack traces to rely on autoindent and the streamindentor. 

Notes:

- It's hard to know how to fix this issue in a clean way because the code that prints stack traces is used everywhere and fixing it to use the autoindentor would not work if we don't also fix the callers to also use autoindentor when they print other things that are not stack traces.

- Fixing directly the library code requires fixing all the usages, knowing that it's likely that breaking the indentation will not be detected by test if some of the usages are not fixed as well.

- Use of streamIndent does not make sense if auto_indent is not enabled, why not always enabling `auto_indent` in the constructor of `streamIndent` and restoring it to its previous state in the destructor ?